### PR TITLE
Config refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that if you are trying to debug outside of an HTML context (e.g. wp-cron, r
 ## Configuration
 By default, all data sources are disabled. You can configure data sources and various other Clockwork settings using the `cfw_config_init` action from within a must-use plugin.
 
-Your callback will receive an instance of `\Clockwork_For_Wp\Private_Schema_Configuration` which implements both `\League\Config\ConfigurationInterface` and `\League\Config\MutableConfigurationInterface`.
+Your callback will receive an instance of `\Clockwork_For_Wp\Configuration`.
 
 This config instance can be used to change any of the configuration options found in `config/schema.php`.
 

--- a/src/Cli_Data_Collection/class-command-context.php
+++ b/src/Cli_Data_Collection/class-command-context.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Clockwork_For_Wp\Cli_Data_Collection;
 
+use Clockwork_For_Wp\Read_Only_Configuration;
 use WP_CLI;
 use WP_CLI\DocParser;
 use WP_CLI\SynopsisParser;
+
+use function Clockwork_For_Wp\service;
 
 final class Command_Context {
 	private $args;
@@ -120,11 +123,9 @@ final class Command_Context {
 			return;
 		}
 
-		$global = \_cfw_instance()->config( 'wp_cli.record_global_parameters', false );
-		$global_runtime = \_cfw_instance()->config(
-			'wp_cli.record_global_runtime_parameters',
-			true
-		);
+		$config = service( Read_Only_Configuration::class );
+		$global = $config->get( 'wp_cli.record_global_parameters', false );
+		$global_runtime = $config->get( 'wp_cli.record_global_runtime_parameters', true );
 		$global_filter = static function ( $option ) {
 			return null !== $option && '' !== $option && [] !== $option;
 		};

--- a/src/Data_Source/class-data-source-provider.php
+++ b/src/Data_Source/class-data-source-provider.php
@@ -8,6 +8,7 @@ use Clockwork_For_Wp\Base_Provider;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
 use Clockwork_For_Wp\Plugin;
 use Clockwork_For_Wp\Provides_Subscriber;
+use Clockwork_For_Wp\Read_Only_Configuration;
 use Pimple\Container;
 
 /**
@@ -28,7 +29,11 @@ final class Data_Source_Provider extends Base_Provider {
 
 	public function register( Plugin $plugin ): void {
 		$plugin->get_pimple()[ Data_Source_Factory::class ] = static function ( Container $pimple ) {
-			return new Data_Source_Factory( $pimple[ Plugin::class ] );
+			return new Data_Source_Factory(
+				$pimple[ Read_Only_Configuration::class ],
+				$pimple[ Plugin::class ]->is(),
+				$pimple
+			);
 		};
 	}
 
@@ -39,7 +44,7 @@ final class Data_Source_Provider extends Base_Provider {
 		$errors = Errors::get_instance();
 
 		if ( $plugin->is()->feature_enabled( 'errors' ) ) {
-			$config = $plugin->config( 'data_sources.errors.config', [] );
+			$config = $plugin->get_pimple()[ Read_Only_Configuration::class ]->get( 'data_sources.errors.config', [] );
 
 			$except_types = $config['except_types'] ?? false;
 			$only_types = $config['only_types'] ?? false;

--- a/src/Wp_Cli/class-clean-command.php
+++ b/src/Wp_Cli/class-clean-command.php
@@ -8,8 +8,7 @@ use ApheleiaCli\Command;
 use ApheleiaCli\Flag;
 use ApheleiaCli\Option;
 use Clockwork\Storage\StorageInterface;
-use League\Config\ConfigurationBuilderInterface;
-use League\Config\ConfigurationInterface;
+use Clockwork_For_Wp\Configuration;
 use Pimple\Container;
 use WP_CLI;
 
@@ -43,11 +42,13 @@ final class Clean_Command extends Command {
 		$all = $assoc_args['all'] ?? false;
 		$expiration = $assoc_args['expiration'] ?? null;
 
+		$config = $this->container[ Configuration::class ];
+
 		if ( $all ) {
-			$this->container[ ConfigurationBuilderInterface::class ]->set( 'storage.expiration', 0 );
+			$config->set( 'storage.expiration', 0 );
 		} elseif ( null !== $expiration ) {
 			// @todo Should we allow float?
-			$this->container[ ConfigurationBuilderInterface::class ]->set(
+			$config->set(
 				'storage.expiration',
 				\abs( (int) $expiration )
 			);
@@ -57,8 +58,6 @@ final class Clean_Command extends Command {
 
 		// See https://github.com/itsgoingd/clockwork/issues/510
 		// @todo Revisit after the release of Clockwork v6.
-		$config = $this->container[ ConfigurationInterface::class ];
-
 		if ( $all && 'file' === $config->get( 'storage.driver', 'file' ) ) {
 			$path = $config->get( 'storage.drivers.file.path' );
 

--- a/src/class-clockwork-provider.php
+++ b/src/class-clockwork-provider.php
@@ -11,6 +11,7 @@ use Clockwork\Helpers\StackFilter;
 use Clockwork\Request\IncomingRequest;
 use Clockwork\Request\Log;
 use Clockwork\Request\Request;
+use Clockwork\Request\ShouldCollect;
 use Clockwork\Storage\StorageInterface;
 use Clockwork_For_Wp\Data_Source\Data_Source_Factory;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
@@ -31,7 +32,8 @@ final class Clockwork_Provider extends Base_Provider {
 
 			$pimple[ Event_Manager::class ]->attach(
 				new Clockwork_Subscriber(
-					$pimple[ Plugin::class ],
+					$pimple[ Read_Only_Configuration::class ],
+					$pimple[ Plugin::class ]->is(),
 					$pimple[ Event_Manager::class ],
 					$pimple[ Clockwork::class ],
 					$pimple[ Request::class ]
@@ -116,51 +118,52 @@ final class Clockwork_Provider extends Base_Provider {
 	}
 
 	public function registered( Plugin $plugin ): void {
-		$this->configure_serializer( $plugin );
-		$this->configure_should_collect( $plugin );
+		$pimple = $plugin->get_pimple();
+		$config = $pimple[ Read_Only_Configuration::class ];
 
-		if ( $plugin->config( 'register_helpers', true ) ) {
+		$this->configure_serializer( $config );
+		$this->configure_should_collect( $pimple[ Clockwork::class ]->shouldCollect(), $config );
+
+		if ( $config->get( 'register_helpers', true ) ) {
 			require_once __DIR__ . '/clock.php';
 		}
 	}
 
-	private function configure_serializer( Plugin $plugin ): void {
+	private function configure_serializer( Read_Only_Configuration $config ): void {
 		Serializer::defaults(
 			[
-				'limit' => $plugin->config( 'serialization.depth', 10 ),
-				'blackbox' => $plugin->config(
+				'limit' => $config->get( 'serialization.depth', 10 ),
+				'blackbox' => $config->get(
 					'serialization.blackbox',
 					[
 						\Pimple\Container::class,
 						\Pimple\Psr11\Container::class,
 					]
 				),
-				'traces' => $plugin->config( 'stack_traces.enabled', true ),
+				'traces' => $config->get( 'stack_traces.enabled', true ),
 				'tracesSkip' => StackFilter::make()
 					->isNotVendor(
 						\array_merge(
-							$plugin->config( 'stack_traces.skip_vendors', [] ),
+							$config->get( 'stack_traces.skip_vendors', [] ),
 							[ 'itsgoingd' ]
 						)
 					)
-					->isNotNamespace( $plugin->config( 'stack_traces.skip_namespaces', [] ) )
+					->isNotNamespace( $config->get( 'stack_traces.skip_namespaces', [] ) )
 					->isNotFunction( [ 'call_user_func', 'call_user_func_array' ] )
-					->isNotClass( $plugin->config( 'stack_traces.skip_classes', [] ) ),
-				'tracesLimit' => $plugin->config( 'stack_traces.limit', 10 ),
+					->isNotClass( $config->get( 'stack_traces.skip_classes', [] ) ),
+				'tracesLimit' => $config->get( 'stack_traces.limit', 10 ),
 			]
 		);
 	}
 
-	private function configure_should_collect( Plugin $plugin ): void {
-		$should_collect = $plugin->get_pimple()[ Clockwork::class ]->shouldCollect();
-
+	private function configure_should_collect( ShouldCollect $should_collect, Read_Only_Configuration $config ): void {
 		$should_collect->merge(
 			[
-				'onDemand' => $plugin->config( 'requests.on_demand', false ),
-				'sample' => $plugin->config( 'requests.sample', false ),
-				'except' => $plugin->config( 'requests.except', [] ),
-				'only' => $plugin->config( 'requests.only', [] ),
-				'exceptPreflight' => $plugin->config( 'requests.except_preflight', true ),
+				'onDemand' => $config->get( 'requests.on_demand', false ),
+				'sample' => $config->get( 'requests.sample', false ),
+				'except' => $config->get( 'requests.except', [] ),
+				'only' => $config->get( 'requests.only', [] ),
+				'exceptPreflight' => $config->get( 'requests.except_preflight', true ),
 			]
 		);
 

--- a/src/class-clockwork-provider.php
+++ b/src/class-clockwork-provider.php
@@ -14,7 +14,6 @@ use Clockwork\Request\Request;
 use Clockwork\Storage\StorageInterface;
 use Clockwork_For_Wp\Data_Source\Data_Source_Factory;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
-use League\Config\ConfigurationInterface;
 use Pimple\Container;
 
 /**
@@ -48,7 +47,7 @@ final class Clockwork_Provider extends Base_Provider {
 			return new Clockwork_Support(
 				$pimple[ Clockwork::class ],
 				$pimple[ Data_Source_Factory::class ],
-				$pimple[ ConfigurationInterface::class ]
+				$pimple[ Read_Only_Configuration::class ]
 			);
 		};
 
@@ -64,7 +63,7 @@ final class Clockwork_Provider extends Base_Provider {
 		};
 
 		$pimple[ AuthenticatorInterface::class ] = static function ( Container $pimple ) {
-			$config = $pimple[ ConfigurationInterface::class ]->get( 'authentication' );
+			$config = $pimple[ Read_Only_Configuration::class ]->get( 'authentication' );
 			$factory = $pimple[ Authenticator_Factory::class ];
 
 			if ( ! ( $config['enabled'] ?? false ) ) {
@@ -81,7 +80,7 @@ final class Clockwork_Provider extends Base_Provider {
 		};
 
 		$pimple[ StorageInterface::class ] = $pimple->factory( static function ( Container $pimple ) {
-			$storage_config = $pimple[ ConfigurationInterface::class ]->get( 'storage' );
+			$storage_config = $pimple[ Read_Only_Configuration::class ]->get( 'storage' );
 			$driver = $storage_config['driver'];
 			$driver_config = $storage_config['drivers'][ $driver ] ?? [];
 

--- a/src/class-clockwork-support.php
+++ b/src/class-clockwork-support.php
@@ -6,7 +6,6 @@ namespace Clockwork_For_Wp;
 
 use Clockwork\Clockwork;
 use Clockwork_For_Wp\Data_Source\Data_Source_Factory;
-use League\Config\ConfigurationInterface;
 
 /**
  * @internal
@@ -18,11 +17,7 @@ final class Clockwork_Support {
 
 	private $factory;
 
-	public function __construct(
-		Clockwork $clockwork,
-		Data_Source_Factory $factory,
-		ConfigurationInterface $config
-	) {
+	public function __construct( Clockwork $clockwork, Data_Source_Factory $factory, Read_Only_Configuration $config ) {
 		$this->clockwork = $clockwork;
 		$this->factory = $factory;
 		$this->config = $config;

--- a/src/class-configuration.php
+++ b/src/class-configuration.php
@@ -24,7 +24,11 @@ final class Configuration {
 		return $this->config->exists( $key );
 	}
 
-	public function get( string $key ) {
+	public function get( string $key, $default = null ) {
+		if ( ! $this->config->exists( $key ) ) {
+			return $default;
+		}
+
 		return $this->config->get( $key );
 	}
 

--- a/src/class-configuration.php
+++ b/src/class-configuration.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Clockwork_For_Wp;
 
+use League\Config\ConfigurationBuilderInterface;
 use League\Config\ConfigurationInterface;
-use League\Config\MutableConfigurationInterface;
 
-/**
- * @internal
- */
-final class Private_Schema_Configuration implements ConfigurationInterface, MutableConfigurationInterface {
+final class Configuration {
+	/**
+	 * @var ConfigurationBuilderInterface&ConfigurationInterface
+	 */
 	private $config;
 
+	/**
+	 * @param ConfigurationBuilderInterface&ConfigurationInterface $config
+	 */
 	public function __construct( $config ) {
 		$this->config = $config;
 	}
@@ -27,6 +30,10 @@ final class Private_Schema_Configuration implements ConfigurationInterface, Muta
 
 	public function merge( array $config = [] ): void {
 		$this->config->merge( $config );
+	}
+
+	public function reader(): Read_Only_Configuration {
+		return new Read_Only_Configuration( $this->config );
 	}
 
 	public function set( string $key, $value ): void {

--- a/src/class-is.php
+++ b/src/class-is.php
@@ -21,13 +21,13 @@ final class Is {
 	}
 
 	public function collecting_client_metrics(): bool {
-		return (bool) $this->config( 'collect_client_metrics', true );
+		return (bool) $this->config->get( 'collect_client_metrics', true );
 	}
 
 	public function collecting_commands(): bool {
-		return ( $this->enabled() || $this->config( 'collect_data_always', false ) )
+		return ( $this->enabled() || $this->config->get( 'collect_data_always', false ) )
 			&& $this->running_in_console()
-			&& $this->config( 'wp_cli.collect', false );
+			&& $this->config->get( 'wp_cli.collect', false );
 	}
 
 	public function collecting_data() {
@@ -35,11 +35,11 @@ final class Is {
 	}
 
 	public function collecting_heartbeat_requests() {
-		return (bool) $this->config( 'collect_heartbeat', true );
+		return (bool) $this->config->get( 'collect_heartbeat', true );
 	}
 
 	public function collecting_requests() {
-		return ( $this->enabled() || $this->config( 'collect_data_always', false ) )
+		return ( $this->enabled() || $this->config->get( 'collect_data_always', false ) )
 			&& ! $this->running_in_console()
 			&& $this->clockwork->shouldCollect()->filter( $this->request )
 			&& ( ! $this->request->is_heartbeat() || $this->collecting_heartbeat_requests() );
@@ -50,15 +50,15 @@ final class Is {
 			return true;
 		}
 
-		$only = $this->config( 'wp_cli.only', [] );
+		$only = $this->config->get( 'wp_cli.only', [] );
 
 		if ( \count( $only ) > 0 ) {
 			return ! \in_array( $command, $only, true );
 		}
 
-		$except = $this->config( 'wp_cli.except', [] );
+		$except = $this->config->get( 'wp_cli.except', [] );
 
-		if ( $this->config( 'wp_cli.except_built_in_commands', true ) ) {
+		if ( $this->config->get( 'wp_cli.except_built_in_commands', true ) ) {
 			$except = \array_merge( $except, Cli_Collection_Helper::get_core_command_list() );
 		}
 
@@ -66,7 +66,7 @@ final class Is {
 	}
 
 	public function enabled() {
-		return (bool) $this->config( 'enable', true );
+		return (bool) $this->config->get( 'enable', true );
 	}
 
 	public function feature_available( $feature ) {
@@ -82,11 +82,11 @@ final class Is {
 	}
 
 	public function feature_enabled( $feature ) {
-		return $this->config( "data_sources.{$feature}.enabled", false ) && $this->feature_available( $feature );
+		return $this->config->get( "data_sources.{$feature}.enabled", false ) && $this->feature_available( $feature );
 	}
 
 	public function recording() {
-		return $this->enabled() || $this->config( 'collect_data_always', false );
+		return $this->enabled() || $this->config->get( 'collect_data_always', false );
 	}
 
 	public function running_in_console() {
@@ -95,11 +95,11 @@ final class Is {
 	}
 
 	public function toolbar_enabled() {
-		return (bool) $this->config( 'toolbar', true );
+		return (bool) $this->config->get( 'toolbar', true );
 	}
 
 	public function web_enabled() {
-		return $this->config( 'enable', true ) && $this->config( 'web', true );
+		return $this->config->get( 'enable', true ) && $this->config->get( 'web', true );
 	}
 
 	public function web_installed() {
@@ -109,14 +109,5 @@ final class Is {
 		}
 
 		return \file_exists( \get_home_path() . '__clockwork/index.html' );
-	}
-
-	// @todo Temporary - revisit after config interface update.
-	private function config( $path, $default = null ) {
-		if ( ! $this->config->exists( $path ) ) {
-			return $default;
-		}
-
-		return $this->config->get( $path );
 	}
 }

--- a/src/class-is.php
+++ b/src/class-is.php
@@ -6,7 +6,6 @@ namespace Clockwork_For_Wp;
 
 use Clockwork\Clockwork;
 use Clockwork_For_Wp\Cli_Data_Collection\Cli_Collection_Helper;
-use League\Config\ConfigurationInterface;
 
 final class Is {
 	private $clockwork;
@@ -15,7 +14,7 @@ final class Is {
 
 	private $request;
 
-	public function __construct( ConfigurationInterface $config, Clockwork $clockwork, Incoming_Request $request ) {
+	public function __construct( Read_Only_Configuration $config, Clockwork $clockwork, Incoming_Request $request ) {
 		$this->config = $config;
 		$this->clockwork = $clockwork;
 		$this->request = $request;

--- a/src/class-plugin-provider.php
+++ b/src/class-plugin-provider.php
@@ -6,9 +6,7 @@ namespace Clockwork_For_Wp;
 
 use Clockwork\Clockwork;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
-use League\Config\Configuration;
-use League\Config\ConfigurationBuilderInterface;
-use League\Config\ConfigurationInterface;
+use League\Config\Configuration as LeagueConfiguration;
 use Pimple\Container;
 
 /**
@@ -26,24 +24,21 @@ final class Plugin_Provider extends Base_Provider {
 
 		$pimple = $plugin->get_pimple();
 
-		$pimple[ ConfigurationBuilderInterface::class ] = static function ( Container $pimple ) {
+		$pimple[ Configuration::class ] = static function ( Container $pimple ) {
 			$schema = include \dirname( __DIR__ ) . '/config/schema.php';
 			$defaults = include \dirname( __DIR__ ) . '/config/defaults.php';
 
-			$config = new Configuration( $schema );
+			$config = new Configuration( new LeagueConfiguration( $schema ) );
 
 			$config->merge( $defaults );
 
-			$pimple[ Event_Manager::class ]->trigger(
-				'cfw_config_init',
-				new Private_Schema_Configuration( $config )
-			);
+			$pimple[ Event_Manager::class ]->trigger( 'cfw_config_init', $config );
 
 			return $config;
 		};
 
-		$pimple[ ConfigurationInterface::class ] = static function ( Container $pimple ) {
-			return $pimple[ ConfigurationBuilderInterface::class ]->reader();
+		$pimple[ Read_Only_Configuration::class ] = static function ( Container $pimple ) {
+			return $pimple[ Configuration::class ]->reader();
 		};
 
 		$pimple[ Metadata::class ] = static function ( Container $pimple ) {

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -15,7 +15,6 @@ use Clockwork_For_Wp\Routing\Routing_Provider;
 use Clockwork_For_Wp\Web_App\Web_App_Provider;
 use Clockwork_For_Wp\Wp_Cli\Wp_Cli_Provider;
 use InvalidArgumentException;
-use League\Config\ConfigurationInterface;
 use Pimple\Container;
 use RuntimeException;
 
@@ -75,11 +74,11 @@ final class Plugin {
 	}
 
 	public function config( $path, $default = null ) {
-		if ( ! isset( $this->pimple[ ConfigurationInterface::class ] ) ) {
+		if ( ! isset( $this->pimple[ Read_Only_Configuration::class ] ) ) {
 			return $default;
 		}
 
-		$config = $this->pimple[ ConfigurationInterface::class ];
+		$config = $this->pimple[ Read_Only_Configuration::class ];
 
 		if ( ! $config->exists( $path ) ) {
 			return $default;
@@ -95,7 +94,7 @@ final class Plugin {
 	public function is(): Is {
 		if ( ! $this->is instanceof Is ) {
 			$this->is = new Is(
-				$this->pimple[ ConfigurationInterface::class ],
+				$this->pimple[ Read_Only_Configuration::class ],
 				$this->pimple[ Clockwork::class ],
 				$this->pimple[ Incoming_Request::class ]
 			);

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -73,20 +73,6 @@ final class Plugin {
 		$this->booted = true;
 	}
 
-	public function config( $path, $default = null ) {
-		if ( ! isset( $this->pimple[ Read_Only_Configuration::class ] ) ) {
-			return $default;
-		}
-
-		$config = $this->pimple[ Read_Only_Configuration::class ];
-
-		if ( ! $config->exists( $path ) ) {
-			return $default;
-		}
-
-		return $config->get( $path );
-	}
-
 	public function get_pimple(): Container {
 		return $this->pimple;
 	}

--- a/src/class-read-only-configuration.php
+++ b/src/class-read-only-configuration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Clockwork_For_Wp;
+
+use League\Config\ConfigurationInterface;
+
+final class Read_Only_Configuration {
+	private ConfigurationInterface $config;
+
+	public function __construct( ConfigurationInterface $config ) {
+		$this->config = $config;
+	}
+
+	public function exists( string $key ): bool {
+		return $this->config->exists( $key );
+	}
+
+	public function get( string $key ) {
+		return $this->config->get( $key );
+	}
+}

--- a/src/class-read-only-configuration.php
+++ b/src/class-read-only-configuration.php
@@ -17,7 +17,11 @@ final class Read_Only_Configuration {
 		return $this->config->exists( $key );
 	}
 
-	public function get( string $key ) {
+	public function get( string $key, $default = null ) {
+		if ( ! $this->config->exists( $key ) ) {
+			return $default;
+		}
+
 		return $this->config->get( $key );
 	}
 }

--- a/tests/Integration/Data_Source/class-data-source-factory-test.php
+++ b/tests/Integration/Data_Source/class-data-source-factory-test.php
@@ -8,9 +8,9 @@ use Clockwork_For_Wp\Data_Source;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
 use Clockwork_For_Wp\Incoming_Request;
 use Clockwork_For_Wp\Plugin;
+use Clockwork_For_Wp\Read_Only_Configuration;
 use Clockwork_For_Wp\Tests\Creates_Config;
 use InvalidArgumentException;
-use League\Config\ConfigurationInterface;
 use PHPUnit\Framework\TestCase;
 
 class Data_Source_Factory_Test extends TestCase {
@@ -97,7 +97,7 @@ class Data_Source_Factory_Test extends TestCase {
 			'wp_version' => 'irrelevant',
 			'timestart' => 'irrelevant',
 			Clockwork::class => new Clockwork(),
-			ConfigurationInterface::class => $this->create_config( [
+			Read_Only_Configuration::class => $this->create_config( [
 				'data_sources' => [
 					'rest_api' => [ 'enabled' => true ],
 					'theme' => [ 'enabled' => false ],

--- a/tests/Integration/Data_Source/class-data-source-factory-test.php
+++ b/tests/Integration/Data_Source/class-data-source-factory-test.php
@@ -7,11 +7,11 @@ use Clockwork\DataSource\DataSource;
 use Clockwork_For_Wp\Data_Source;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
 use Clockwork_For_Wp\Incoming_Request;
-use Clockwork_For_Wp\Plugin;
-use Clockwork_For_Wp\Read_Only_Configuration;
+use Clockwork_For_Wp\Is;
 use Clockwork_For_Wp\Tests\Creates_Config;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Pimple\Container;
 
 class Data_Source_Factory_Test extends TestCase {
 	use Creates_Config;
@@ -93,28 +93,30 @@ class Data_Source_Factory_Test extends TestCase {
 	}
 
 	protected function create_factory() {
-		return new Data_Source\Data_Source_Factory( new Plugin( [], [
+		$config = $this->create_config( [
+			'data_sources' => [
+				'rest_api' => [ 'enabled' => true ],
+				'theme' => [ 'enabled' => false ],
+				'transients' => [ 'enabled' => true ],
+			],
+		] );
+		$clockwork = new Clockwork();
+		$request = new Incoming_Request( [
+			'ajax_uri' => 'localhost/wp-admin/admin-ajax.php',
+			'cookies' => [],
+			'headers' => [],
+			'input' => [],
+			'method' => 'GET',
+			'uri' => '/',
+		] );
+		$pimple = new Container( [
 			'wp_version' => 'irrelevant',
 			'timestart' => 'irrelevant',
-			Clockwork::class => new Clockwork(),
-			Read_Only_Configuration::class => $this->create_config( [
-				'data_sources' => [
-					'rest_api' => [ 'enabled' => true ],
-					'theme' => [ 'enabled' => false ],
-					'transients' => [ 'enabled' => true ],
-				],
-			] ),
 			Event_Manager::class => new class {
 				public function trigger() { /** irrelevant */ }
-			},
-			Incoming_Request::class => new Incoming_Request( [
-				'ajax_uri' => 'localhost/wp-admin/admin-ajax.php',
-				'cookies' => [],
-				'headers' => [],
-				'input' => [],
-				'method' => 'GET',
-				'uri' => '/',
-			] ),
-		] ) );
+			}
+		] );
+
+		return new Data_Source\Data_Source_Factory( $config, new Is( $config, $clockwork, $request ), $pimple );
 	}
 }

--- a/tests/Integration/Data_Source/class-wp-hook-test.php
+++ b/tests/Integration/Data_Source/class-wp-hook-test.php
@@ -2,15 +2,19 @@
 
 namespace Clockwork_For_Wp\Tests\Integration\Data_Source;
 
+use Clockwork\Clockwork;
 use Clockwork\Request\Request;
-use Clockwork_For_Wp\Config;
 use Clockwork_For_Wp\Data_Source\Data_Source_Factory;
-use Clockwork_For_Wp\Data_Source\Data_Source_Provider;
 use Clockwork_For_Wp\Data_Source\Wp_Hook;
-use Clockwork_For_Wp\Plugin;
+use Clockwork_For_Wp\Incoming_Request;
+use Clockwork_For_Wp\Is;
+use Clockwork_For_Wp\Tests\Creates_Config;
 use PHPUnit\Framework\TestCase;
+use Pimple\Container;
 
 class Wp_Hook_Test extends TestCase {
+	use Creates_Config;
+
 	/** @test */
 	public function it_correctly_records_hook_data() {
 		$data_source = new Wp_Hook();
@@ -233,7 +237,14 @@ class Wp_Hook_Test extends TestCase {
 	}
 
 	protected function create_data_source_via_factory( $filters = [] ) {
-		return ( new Data_Source_Factory( new Plugin() ) )->create(
+		$config = $this->create_config();
+		$factory = new Data_Source_Factory(
+			$config,
+			new Is( $config, new Clockwork(), new Incoming_Request() ),
+			new Container()
+		);
+
+		return $factory->create(
 			'wp_hook',
 			[
 				'except_callbacks' => $filters['except_callbacks'] ?? [],

--- a/tests/Integration/Data_Source/class-wpdb-test.php
+++ b/tests/Integration/Data_Source/class-wpdb-test.php
@@ -2,16 +2,20 @@
 
 namespace Clockwork_For_Wp\Tests\Integration\Data_Source;
 
-use Clockwork_For_Wp\Config;
-use Clockwork_For_Wp\Data_Source\Data_Source_Provider;
+use Clockwork\Clockwork;
 use Clockwork_For_Wp\Data_Source\Wpdb;
 use Clockwork_For_Wp\Event_Management\Event_Manager;
-use Clockwork_For_Wp\Plugin;
 use Clockwork\Request\Request;
 use Clockwork_For_Wp\Data_Source\Data_Source_Factory;
+use Clockwork_For_Wp\Incoming_Request;
+use Clockwork_For_Wp\Is;
+use Clockwork_For_Wp\Tests\Creates_Config;
 use PHPUnit\Framework\TestCase;
+use Pimple\Container;
 
 class Wpdb_Test extends TestCase {
+	use Creates_Config;
+
 	protected function pattern_model_map() {
 		// @todo Can we pull this from the bundled config? Would require a method for removing WP constants as dependencies of the config.php file.
 		return [
@@ -182,17 +186,25 @@ class Wpdb_Test extends TestCase {
 		$this->assertEquals( 'TESTMODEL', $request->databaseQueries[0]['model'] );
 	}
 
-	protected function create_data_source_via_factory( $config = [] ) {
-		return ( new Data_Source_Factory( new Plugin( [], [
-			Event_Manager::class => new class {
-				public function trigger( ...$args ) {
-					// Not important...
-				}
-			},
-		] ) ) )->create( 'wpdb', [
-			'pattern_model_map' => $config['pattern_model_map'] ?? $this->pattern_model_map(),
-			'slow_only' => $config['slow_only'] ?? false,
-			'slow_threshold' => $config['slow_threshold'] ?? 50
+	protected function create_data_source_via_factory( $user_config = [] ) {
+		$config = $this->create_config();
+
+		$factory = new Data_Source_Factory(
+			$config,
+			new Is( $config, new Clockwork(), new Incoming_Request() ),
+			new Container( [
+				Event_Manager::class => new class {
+					public function trigger( ...$args ) {
+						// Not important...
+					}
+				},
+			] )
+		);
+
+		return $factory->create( 'wpdb', [
+			'pattern_model_map' => $user_config['pattern_model_map'] ?? $this->pattern_model_map(),
+			'slow_only' => $user_config['slow_only'] ?? false,
+			'slow_threshold' => $user_config['slow_threshold'] ?? 50
 		] );
 	}
 }

--- a/tests/Integration/class-clockwork-provider-test.php
+++ b/tests/Integration/class-clockwork-provider-test.php
@@ -4,9 +4,9 @@ namespace Clockwork_For_Wp\Tests\Integration;
 
 use Clockwork_For_Wp\Clockwork_Provider;
 use Clockwork_For_Wp\Plugin;
+use Clockwork_For_Wp\Read_Only_Configuration;
 use Clockwork_For_Wp\Storage_Factory;
 use Clockwork_For_Wp\Tests\Creates_Config;
-use League\Config\ConfigurationInterface;
 use Null_Storage_For_Tests;
 use PHPUnit\Framework\TestCase;
 
@@ -50,7 +50,7 @@ class Clockwork_Provider_Test extends TestCase {
 
 	private function create_plugin( array $user_config = [] ) {
 		$plugin = new Plugin( [], [
-			ConfigurationInterface::class => $this->create_config( $user_config ),
+			Read_Only_Configuration::class => $this->create_config( $user_config ),
 		] );
 
 		$plugin->register( new Clockwork_Provider( $plugin ) );

--- a/tests/Integration/class-plugin-test.php
+++ b/tests/Integration/class-plugin-test.php
@@ -5,13 +5,10 @@ namespace Clockwork_For_Wp\Tests\Integration;
 use Clockwork\Clockwork;
 use Clockwork\Request\IncomingRequest;
 use Clockwork_For_Wp\Clockwork_Provider;
-use Clockwork_For_Wp\Configuration;
 use Clockwork_For_Wp\Plugin;
 use Clockwork_For_Wp\Read_Only_Configuration;
 use Clockwork_For_Wp\Storage_Factory;
 use Clockwork_For_Wp\Tests\Creates_Config;
-use League\Config\Configuration as LeagueConfiguration;
-use Nette\Schema\Expect;
 use Null_Storage_For_Tests;
 use PHPUnit\Framework\TestCase;
 
@@ -23,18 +20,6 @@ class Plugin_Test extends TestCase {
 		$plugin = new Plugin( [], [ 'a' => 'b' ] );
 
 		$this->assertEquals( 'b', $plugin->get_pimple()[ 'a' ] );
-	}
-
-	/** @test */
-	public function it_provides_access_to_config_object() {
-		$config = new Configuration( new LeagueConfiguration( [ 'a' => Expect::string() ] ) );
-		$config->merge( [ 'a' => 'b' ] );
-		$plugin = new Plugin( [], [
-			Read_Only_Configuration::class => $config->reader(),
-		] );
-
-		$this->assertEquals( 'b', $plugin->config( 'a' ) );
-		$this->assertEquals( 'default', $plugin->config( 'b', 'default' ) );
 	}
 
 	/** @test */

--- a/tests/Integration/class-plugin-test.php
+++ b/tests/Integration/class-plugin-test.php
@@ -5,12 +5,12 @@ namespace Clockwork_For_Wp\Tests\Integration;
 use Clockwork\Clockwork;
 use Clockwork\Request\IncomingRequest;
 use Clockwork_For_Wp\Clockwork_Provider;
-use Clockwork_For_Wp\Incoming_Request;
+use Clockwork_For_Wp\Configuration;
 use Clockwork_For_Wp\Plugin;
+use Clockwork_For_Wp\Read_Only_Configuration;
 use Clockwork_For_Wp\Storage_Factory;
 use Clockwork_For_Wp\Tests\Creates_Config;
-use League\Config\Configuration;
-use League\Config\ConfigurationInterface;
+use League\Config\Configuration as LeagueConfiguration;
 use Nette\Schema\Expect;
 use Null_Storage_For_Tests;
 use PHPUnit\Framework\TestCase;
@@ -27,10 +27,10 @@ class Plugin_Test extends TestCase {
 
 	/** @test */
 	public function it_provides_access_to_config_object() {
-		$config = new Configuration( [ 'a' => Expect::string() ] );
+		$config = new Configuration( new LeagueConfiguration( [ 'a' => Expect::string() ] ) );
 		$config->merge( [ 'a' => 'b' ] );
 		$plugin = new Plugin( [], [
-			ConfigurationInterface::class => $config,
+			Read_Only_Configuration::class => $config->reader(),
 		] );
 
 		$this->assertEquals( 'b', $plugin->config( 'a' ) );
@@ -143,7 +143,7 @@ class Plugin_Test extends TestCase {
 
 	private function create_plugin_with_configuration( array $user_config = [] ) {
 		$plugin = new Plugin( [], [
-			ConfigurationInterface::class => $this->create_config( $user_config ),
+			Read_Only_Configuration::class => $this->create_config( $user_config ),
 		] );
 
 		return $plugin;

--- a/tests/fixtures/plugins/cfw-test-helper/class-metadata.php
+++ b/tests/fixtures/plugins/cfw-test-helper/class-metadata.php
@@ -2,7 +2,7 @@
 
 namespace Cfw_Test_Helper;
 
-use League\Config\ConfigurationInterface;
+use Clockwork_For_Wp\Read_Only_Configuration;
 
 use function Clockwork_For_Wp\service;
 
@@ -11,7 +11,7 @@ use function Clockwork_For_Wp\service;
 //       https://github.com/itsgoingd/clockwork/issues/510
 class Metadata {
 	public static function dir() {
-		$config = service( ConfigurationInterface::class );
+		$config = service( Read_Only_Configuration::class );
 
 		if ( 'file' !== $config->get( 'storage.driver' ) ) {
 			throw new \RuntimeException(

--- a/tests/trait-creates-config.php
+++ b/tests/trait-creates-config.php
@@ -2,14 +2,15 @@
 
 namespace Clockwork_For_Wp\Tests;
 
-use League\Config\Configuration;
-use League\Config\ConfigurationInterface;
+use Clockwork_For_Wp\Configuration;
+use Clockwork_For_Wp\Read_Only_Configuration;
+use League\Config\Configuration as LeagueConfiguration;
 
 trait Creates_Config {
-	public function create_config( array $user_config = [] ): ConfigurationInterface {
+	public function create_config( array $user_config = [] ): Read_Only_Configuration {
 		$schema = include dirname( __DIR__ ) . '/config/schema.php';
 
-		$config = new Configuration( $schema );
+		$config = new Configuration( new LeagueConfiguration( $schema ) );
 
 		$config->merge( $user_config );
 


### PR DESCRIPTION
Creates dedicated config classes instead of continuing to rely on third party league interfaces.

Allows us to add the "default" param to config::get() which in turn lets us get rid of the config method on the plugin class allowing us to remove direct dependencies on plugin class when all that is really needed is access to config.